### PR TITLE
Explicitly exposing keyboard states for aria labeling

### DIFF
--- a/src/react-dnd-ax/drag-n-drop-container.js
+++ b/src/react-dnd-ax/drag-n-drop-container.js
@@ -281,6 +281,8 @@ const DragNDropContainer = (WrappedComponent) => {
             {...this.props}
             state={this.state}
             actions={this.actions}
+            keyInsertIndex={state.keyInsertIndex}
+            isKeyboardMoving={state.isKeyboardMoving}
           />
         </div>
       )


### PR DESCRIPTION
ULTRA-28382 - Explicitly exposing isKeyboardMoving and keyInsertIndex states so they can be used to show related aria-label information for drag state. When keyboard drag is happening (isKeyboardMoving) we need to change the aria-label to say 'drop' and tell the item it will be dropped after (keyInsertIndex - 1). Explicitly exposing them as props to make the dependency clear and avoid regressions.