### PR TITLE
Fix: trigger click action on enter for drag element 

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "promise": "7.1.1",
     "react": "15.6.1",
     "react-dev-utils": "3.0.0",
-    "react-dnd-ax": "1.0.5",
+    "react-dnd-ax": "1.0.12",
     "react-dom": "15.6.1",
     "react-error-overlay": "1.0.7",
     "react-fa": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "promise": "7.1.1",
     "react": "15.6.1",
     "react-dev-utils": "3.0.0",
-    "react-dnd-ax": "1.0.12",
+    "react-dnd-ax": "1.0.13",
     "react-dom": "15.6.1",
     "react-error-overlay": "1.0.7",
     "react-fa": "4.2.0",

--- a/src/examples/basic-example/BasicExample.js
+++ b/src/examples/basic-example/BasicExample.js
@@ -26,15 +26,16 @@ class BasicExample extends React.Component {
           ref={itemRef} // mandatory: put this attribute to the container element of the movable item
         >
             <span className="text">{item.text}</span>
-            <button
+            <div // mandatory if supporting FireFox. FireFox does not support dragstart event on buttons.
               ref={dragPointRef} // mandatory: put this attribute to the drag handler
               className="drag-point"
               draggable // mandatory HTML attribute for drag handler
               tabIndex="0" // mandatory HTML attribute, make it possible to focus on the drag handler
               title="Drag this link to reorder the item" // AX title
+              role="button" // mandatory if element is not a button
             >
               <Icon name="arrows"/>
-            </button>
+            </div>
         </div>
       )
     })

--- a/src/react-dnd-ax/drag-n-drop-item.js
+++ b/src/react-dnd-ax/drag-n-drop-item.js
@@ -41,6 +41,7 @@ const DragNDropItem = (WrappedComponent) => {
           actions.onTouchMove(e, this.dragPreviewRef)
         })
         this.dragPointElem.addEventListener('click', this.onClick)
+        this.dragPointElem.addEventListener('keyup', this.onEnter)
         this.itemRef.addEventListener('keydown', actions.onKeyChangeOrder)
       }
     }
@@ -94,6 +95,8 @@ const DragNDropItem = (WrappedComponent) => {
         this.dragPointElem.addEventListener('dragstart', this.onSetImageDragStart)
         this.dragPointElem.removeEventListener('click', this.onClick)
         this.dragPointElem.addEventListener('click', this.onClick)
+        this.dragPointElem.removeEventListener('keyup', this.onEnter)
+        this.dragPointElem.addEventListener('keyup', this.onEnter)
       }
 
       if (this.firstKeyInsertPlaceHolderRef && this.firstKeyInsertPlaceHolderRef.className.includes('show')) {
@@ -132,6 +135,12 @@ const DragNDropItem = (WrappedComponent) => {
       const { index, actions, preview } = this.props
 
       actions.onClickDrag(e, index, preview)
+    }
+
+    onEnter = (e) => {
+      if (e.key === 'Enter' || e.keyCode === 13) {
+        this.onClick(e);
+      }
     }
 
     onDropNextIndex = (e) => {


### PR DESCRIPTION
We found in our testing environment when integrating a fix to allow drag/ drop in FireFox that we could enter the drag/ drop state with a div. A button by default triggers the click event on enter, so it was never an issue before. Along with adding the keyup listener on the drag-n-drop-item HOC, I also updated the example to use a div instead of a button so others can see the behavior and upped the react-dnd-ax dependency from 1.0.5 to 1.0.12 to match the current version.