### PR TITLE
[LRN-149117] Improve performance for large lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dnd-ax",
-  "version": "1.2.4",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dnd-ax",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "React drag and drop HOC with accessibility and keyboard actions support.",
   "main": "dist/commonjs/index.js",
   "jsnext:main": "dist/es6/index.js",

--- a/src/react-dnd-ax/drag-n-drop-item.js
+++ b/src/react-dnd-ax/drag-n-drop-item.js
@@ -118,11 +118,10 @@ const DragNDropItem = (WrappedComponent) => {
         this.itemRef.focus()
       }
 
-      if (this.previewWidth == null) {
-          this.previewWidth = getComputedStyle(this.itemRef).getPropertyValue('width')
-      }
-
       if (this.dragPreviewRef && this.dragPreviewRef.style && this.dragPreviewRef.className && this.dragPreviewRef.className.includes('show')) {
+        if (this.previewWidth == null) {
+          this.previewWidth = getComputedStyle(this.itemRef).getPropertyValue('width')
+        }
         this.dragPreviewRef.style.width = this.previewWidth
       }
     }


### PR DESCRIPTION
The problem
------------

On a large list with many drag-and-drop components, we found DragNDropItem may call a time consuming getComputedStyle() in componentDidUpdate.

The update can be triggered right after initial mounting by some life-cycle hooks (for example translate a string asynchronously and then setState()).

The code change
-----------------

Move the expensive set previewWidth to just before showing preview.

The improvement
-----------------

We recorded the performance in Chrome, and rendered a page with 100 components (each component is wrapped in DragNDropItem). The percentage of time spent on DragNDropItem.componentDidUpdate() was recorded.

Before: 2.1%, 0.6%, 0.6%, 1.9% (4 repetitions)
After: 0.5%, 0.4%, 0.4%, 0.4%, 0.4% (5 repetitions)